### PR TITLE
aws-sdk-cpp 1.11.528 rebuild

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 channels:
-  - https://staging.continuum.io/prefect/fs/aws-crt-cpp-feedstock/pr3/922b0a8
+  - https://staging.continuum.io/prefect/fs/aws-crt-cpp-feedstock/pr3/5ecd966

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/aws-crt-cpp-feedstock/pr3/5ecd966

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/aws-crt-cpp-feedstock/pr3/922b0a8

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,8 @@ requirements:
     - aws-c-common 0.12.3
     - aws-c-event-stream 0.5.5
     - aws-crt-cpp 0.32.10
-    - libcurl
-    - zlib
+    - libcurl {{ libcurl }}
+    - zlib  {{ zlib }}
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,8 +25,8 @@ requirements:
     - aws-c-common 0.12.3
     - aws-c-event-stream 0.5.4
     - aws-crt-cpp 0.31.0
-    - libcurl
-    - zlib
+    - libcurl {{ libcurl }}
+    - zlib  {{ zlib }}
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,10 +23,10 @@ requirements:
     - make  # [unix]
   host:
     - aws-c-common 0.12.3
-    - aws-c-event-stream 0.5.4
-    - aws-crt-cpp 0.31.0
-    - libcurl {{ libcurl }}
-    - zlib  {{ zlib }}
+    - aws-c-event-stream 0.5.5
+    - aws-crt-cpp 0.32.10
+    - libcurl
+    - zlib
 
 test:
   files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: c805b65a76d48995b04c6d6ec3f94c71c34c0e068afd40ef43897e212b871938
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage("aws-sdk-cpp", max_pin="x.x.x") }}
 
@@ -22,11 +22,11 @@ requirements:
     - ninja-base
     - make  # [unix]
   host:
-    - aws-c-common 0.11.1
+    - aws-c-common 0.12.3
     - aws-c-event-stream 0.5.4
     - aws-crt-cpp 0.31.0
-    - libcurl {{ libcurl }}
-    - zlib  {{ zlib }}
+    - libcurl
+    - zlib
 
 test:
   files:


### PR DESCRIPTION
aws-sdk-cpp 1.11.528 

**Destination channel:** Defaults

### Links

- [PKG-8664]
- dev_url:        https://github.com/aws/aws-sdk-cpp/tree/1.11.528
- conda_forge:    https://github.com/conda-forge/aws-sdk-cpp-feedstock
- pypi:           https://pypi.org/project/aws-sdk-cpp/1.11.528
- pypi inspector: https://inspector.pypi.io/project/aws-sdk-cpp/1.11.528/

### Explanation of changes:

- rebuild due to new dependency verions


[PKG-8664]: https://anaconda.atlassian.net/browse/PKG-8664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ