### PR TITLE
Update version to 1.11.720

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -7,6 +7,7 @@ pushd "%SRC_DIR%"\build
 cmake -LAH -G "Ninja" ^
       -DCMAKE_INSTALL_PREFIX="%LIBRARY_PREFIX%" ^
       -DCMAKE_INSTALL_LIBDIR=lib ^
+      -DCMAKE_INSTALL_BINDIR=bin ^
       -DCMAKE_MODULE_PATH:PATH="%LIBRARY_LIB%\cmake" ^
       -DAWS_SDK_WARNINGS_ARE_ERRORS=OFF ^
       -DBUILD_ONLY="s3;core;transfer;config;identity-management;sts;sqs;sns;monitoring;logs" ^

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,6 +18,7 @@ cmake -LAH -G "Ninja" ^
       -DFORCE_CURL=ON ^
       -DCURL_HAS_H2=ON ^
       -DCURL_HAS_TLS_PROXY=ON ^
+      -DLEGACY_BUILD=OFF ^
       ..
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,7 +18,7 @@ cmake -LAH -G "Ninja" ^
       -DFORCE_CURL=ON ^
       -DCURL_HAS_H2=ON ^
       -DCURL_HAS_TLS_PROXY=ON ^
-      -DSIMPLE_INSTALL=OFF ^
+      -DCMAKE_POLICY_DEFAULT_CMP0177=OLD ^
       ..
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,7 +18,6 @@ cmake -LAH -G "Ninja" ^
       -DFORCE_CURL=ON ^
       -DCURL_HAS_H2=ON ^
       -DCURL_HAS_TLS_PROXY=ON ^
-      -DCMAKE_POLICY_DEFAULT_CMP0177=OLD ^
       ..
 if errorlevel 1 exit 1
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -18,7 +18,7 @@ cmake -LAH -G "Ninja" ^
       -DFORCE_CURL=ON ^
       -DCURL_HAS_H2=ON ^
       -DCURL_HAS_TLS_PROXY=ON ^
-      -DLEGACY_BUILD=OFF ^
+      -DSIMPLE_INSTALL=OFF ^
       ..
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -9,6 +9,7 @@ cmake ${CMAKE_ARGS} .. -GNinja \
   -DCMAKE_INSTALL_LIBDIR=lib \
   -DCMAKE_MODULE_PATH="${PREFIX}/lib/cmake" \
   -DBUILD_ONLY='s3;core;transfer;config;identity-management;sts;sqs;sns;monitoring;logs' \
+  -DAWS_SDK_WARNINGS_ARE_ERRORS=OFF \
   -DENABLE_UNITY_BUILD=ON \
   -DENABLE_TESTING=OFF \
   -DCMAKE_BUILD_TYPE=Release \

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-MACOSX_SDK_VERSION:  # [osx and x86_64]
-  - 10.15            # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-sdk-cpp" %}
-{% set version = "1.11.638" %}
+{% set version = "1.11.718" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/aws/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: c4392d648beff7ed503485c48e6e2165b3356c0a6625ce5a286b421817321c38
+  sha256: 02948abc48c1b24d8156c4514f8318db2e0e3073f7ef2d7025c44ab8ca7758b2
 
 build:
   number: 0
@@ -23,9 +23,9 @@ requirements:
     - ninja-base
     - make  # [unix]
   host:
-    - aws-c-common 0.12.4
-    - aws-c-event-stream 0.5.6
-    - aws-crt-cpp 0.34.0
+    - aws-c-common 0.12.6
+    - aws-c-event-stream 0.5.9
+    - aws-crt-cpp 0.35.4
     - libcurl {{ libcurl }}
     - zlib  {{ zlib }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-sdk-cpp" %}
-{% set version = "1.11.718" %}
+{% set version = "1.11.720" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/aws/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 02948abc48c1b24d8156c4514f8318db2e0e3073f7ef2d7025c44ab8ca7758b2
+  sha256: 6b0f56e8f6f7d5a837e73173646630161c2b7419ed178afc3f5fd5b7bab25e11
 
 build:
   number: 0


### PR DESCRIPTION
aws-sdk-cpp 1.11.720

**Destination channel:** defaults

### Links

- [PKG-10905](https://anaconda.atlassian.net/browse/PKG-10905) 
- [Upstream repository](https://github.com/aws/aws-sdk-cpp)

### Explanation of changes:

- New version number
- Update of dependencies
- Using default MacOSX SDK - 12
- Add install bindir for windows build
- Ignore warning for linux build


[PKG-10905]: https://anaconda.atlassian.net/browse/PKG-10905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ